### PR TITLE
Add Ubuntu build support

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -109,6 +109,18 @@ get_required_libs() {
             elfutils-libelf \
             elfutils-libelf-devel\
             fmt-devel
+    elif [ -x "$(command -v apt)" ]; then
+        sudo apt install -y --no-install-recommends \
+          curl \
+          ca-certificates \
+          libelf-dev \
+          libfmt-dev \
+          libbpf-dev \
+          build-essential \
+          clang \
+          cmake \
+          linux-tools-common \
+          linux-tools-$(uname -r)
     else
         sudo yum install -y \
             git \


### PR DESCRIPTION
Known to function for Ubuntu 22.04 and 24.04.

Tested with docker tags for `ubuntu:24.04` and `ubuntu:22.04` using:
```
docker run \
  -v "$(pwd)":/usr/src \
  -v /sys:/sys:ro \
  --rm \
  -it \
  ubuntu:24.04 \
  /bin/bash -c 'pushd /usr/src && apt update && apt install -y sudo && ./scripts/build.sh'
```